### PR TITLE
fix: disable scroll snapping

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -8,10 +8,6 @@
   --link-color: #088F9C;
 }
 
-html {
-  scroll-snap-type: y proximity;
-}
-
 body {
   background-image: url("assets/backgrounds/hbox\ stare.png");
   background-repeat: no-repeat;
@@ -29,7 +25,6 @@ body {
   font-family: "Montserrat", sans-serif;
   font-optical-sizing: auto;
   font-style: normal;
-  scroll-snap-align: start;
 }
 
 h1 {
@@ -87,8 +82,6 @@ ul {
   margin: 20px;
   font-size: 16px;
   transition: all 200ms, border 500ms;
-  scroll-margin: 20px;
-  scroll-snap-align: start;
 }
 
 .card:hover {


### PR DESCRIPTION
Several people already mentioned that the scroll snapping is erratic and difficult to use on mobile. Rather than tweaking the parameters to make it less aggressive, it's probably simplest just to remove it altogether.