### PR TITLE
feat: add analytics

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" href="assets/favicon.png">
     <script src="script.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="2e6188c4-56e6-49cc-bd9e-511523dc3fb7"></script>
 </head>
 
 <body>
@@ -34,14 +35,14 @@
                     </ul>
                 </div>
                 <hr>
-                <p><a href="https://maps.app.goo.gl/naFGgKkRKom8eME57" target="_blank">Gresham, OR</a> | <b>attendees:</b> 400+</p>
+                <p><a href="https://maps.app.goo.gl/naFGgKkRKom8eME57" target="_blank" data-umami-event="map-link-clicked" data-umami-event-location="Gresham, OR">Gresham, OR</a> | <b>attendees:</b> 400+</p>
                 <hr>
                 <div class="buttons">
                     <a href="https://www.start.gg/tournament/smash-camp-new-lands-2024/details" target="_blank"
-                        class="card-button">start.gg</a>
+                        class="card-button" data-umami-event="start-gg-clicked" data-umami-event-name="Smash Camp">start.gg</a>
                         <!-- <a href="https://www.start.gg/tournament/tipped-off-15-connected-1/details" target="_blank"
-                        class="card-button">schedule</a> -->
-                    <a href="https://www.twitch.tv/Level1_TV" target="_blank" class="card-button">stream</a>
+                        class="card-button" data-umami-event="schedule-clicked" data-umami-event-name="Smash Camp">schedule</a> -->
+                    <a href="https://www.twitch.tv/Level1_TV" target="_blank" class="card-button" data-umami-event="stream-link-clicked" data-umami-event-name="Smash Camp">stream</a>
                 </div>
             </div>
         </div>
@@ -64,14 +65,14 @@
                     </ul>
                 </div>
                 <hr>
-                <p><a href="https://maps.app.goo.gl/4xa7DWr8bYn9XH4H8" target="_blank">Marietta, GA</a> | <b>attendees:</b> 250+</p>
+                <p><a href="https://maps.app.goo.gl/4xa7DWr8bYn9XH4H8" target="_blank" data-umami-event="map-link-clicked" data-umami-event-location="Marietta, GA">Marietta, GA</a> | <b>attendees:</b> 250+</p>
                 <hr>
                 <div class="buttons">
                     <a href="https://www.start.gg/tournament/tipped-off-15-connected-1/details" target="_blank"
-                        class="card-button">start.gg</a>
+                        class="card-button" data-umami-event="start-gg-clicked" data-umami-event-name="Tipped Off">start.gg</a>
                     <a href="https://www.start.gg/tournament/tipped-off-15-connected-1/details" target="_blank"
-                        class="card-button">schedule</a>
-                    <a href="https://twitch.tv/Mang0" target="_blank" class="card-button">stream</a>
+                        class="card-button"  data-umami-event="schedule-clicked" data-umami-event-name="Tipped Off">schedule</a>
+                    <a href="https://twitch.tv/Mang0" target="_blank" class="card-button" data-umami-event="stream-clicked" data-umami-event-name="Tipped Off">stream</a>
                 </div>
             </div>
         </div>
@@ -95,16 +96,16 @@
                 </div>
                 <hr>
                 <p>
-                    <a href="https://maps.app.goo.gl/K19xfyePawTfPrwi8" target="_blank">Daytona Beach, FL</a>
+                    <a href="https://maps.app.goo.gl/K19xfyePawTfPrwi8" target="_blank"  data-umami-event="map-link-clicked" data-umami-event-location="Daytona Beach, FL">Daytona Beach, FL</a>
                     |
                     <b>attendees:</b> TBD</p>
                 <hr>
                 <div class="buttons">
                     <a href="https://www.start.gg/tournament/ceo-2024-6" target="_blank"
-                        class="card-button">start.gg</a>
-                    <a href="https://ceogaming.org/ceo/#:~:text=CEO%202024%20GENERAL%20EVENT%20SCHEDULE" target="_blank"
+                        class="card-button" data-umami-event="start-gg-clicked" data-umami-event-name="CEO 2024">start.gg</a>
+                    <a href="https://ceogaming.org/ceo/#:~:text=CEO%202024%20GENERAL%20EVENT%20SCHEDULE" target="_blank"  data-umami-event="schedule-clicked" data-umami-event-name="CEO 2024"
                         class="card-button">schedule</a>
-                    <!-- <a href="https://twitch.tv/Mang0" target="_blank" class="card-button">stream</a> -->
+                    <!-- <a href="https://twitch.tv/Mang0" target="_blank" class="card-button"  data-umami-event="stream-clicked" data-umami-event-name="CEO 2024">stream</a> -->
                 </div>
             </div>
         </div>
@@ -128,16 +129,16 @@
                 </div>
                 <hr>
                 <p>
-                    <a href="https://maps.app.goo.gl/rs4L8qvj1JSGWEid6" target="_blank">Chantilly, VA</a>
+                    <a href="https://maps.app.goo.gl/rs4L8qvj1JSGWEid6" target="_blank"  data-umami-event="map-link-clicked" data-umami-event-location="Chantilly, VA">Chantilly, VA</a>
                     |
                     <b>attendees:</b> TBD</p>
                 <hr>
                 <div class="buttons">
                     <a href="https://www.start.gg/tournament/supernova-2024" target="_blank"
-                        class="card-button">start.gg</a>
+                        class="card-button" data-umami-event="start-gg-clicked" data-umami-event-name="Supernova 2024">start.gg</a>
                     <!-- <a href="https://www.start.gg/tournament/tipped-off-15-connected-1/details" target="_blank"
-                        class="card-button">schedule</a> -->
-                    <!-- <a href="https://twitch.tv/Mang0" target="_blank" class="card-button">stream</a> -->
+                        class="card-button" data-umami-event="schedule-clicked" data-umami-event-name="Supernova 2024">schedule</a> -->
+                    <!-- <a href="https://twitch.tv/Mang0" target="_blank" class="card-button" data-umami-event="stream-clicked" data-umami-event-name="Supernova 2024">stream</a> -->
                 </div>
             </div>
         </div>
@@ -161,27 +162,27 @@
                 </div>
                 <hr>
                 <p>
-                    <a href="https://maps.app.goo.gl/i9iTShDJm5JkFpGH9" target="_blank">Seattle, WA</a>
+                    <a href="https://maps.app.goo.gl/i9iTShDJm5JkFpGH9" target="_blank" data-umami-event="map-link-clicked" data-umami-event-location="Seattle, WA">Seattle, WA</a>
                     |
                     <b>attendees:</b> 500+</p>
                 <hr>
                 <div class="buttons">
                     <a href="https://www.start.gg/tournament/don-t-park-on-the-grass-2024" target="_blank"
-                        class="card-button">start.gg</a>
+                        class="card-button" data-umami-event="start-gg-clicked" data-umami-event-name="Don't Park on the Grass">start.gg</a>
                     <!-- <a href="https://www.start.gg/tournament/tipped-off-15-connected-1/details" target="_blank"
-                        class="card-button">schedule</a> -->
-                    <!-- <a href="https://twitch.tv/Mang0" target="_blank" class="card-button">stream</a> -->
+                        class="card-button" data-umami-event="schedule-clicked" data-umami-event-name="Don't Park on the Grass">schedule</a> -->
+                    <!-- <a href="https://twitch.tv/Mang0" target="_blank" class="card-button" data-umami-event="stream-clicked" data-umami-event-name="Don't Park on the Grass">stream</a> -->
                 </div>
             </div>
         </div>
     </div>
     <footer>
         <div class="footer">
-            <p>see something wrong? open an issue or pull request on our <a href="https://github.com/jtof-dev/meleemajors.gg">github repo</a></p>
-            <p>this <a href="https://github.com/jtof-dev/meleemajors.gg" target="_blank">website</a> is
-            open-source, and is licensed under <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank">agpl-3</a></p>
-            <p>powered by <a href="https://pages.github.com" target="_blank">github
-            pages</a> | made with love by <a href="https://github.com/jtof-dev" target="_blank">jtof</a> and <a href="https://github.com/nathanbabcock" target="_blank">excalo</a></p>
+            <p>see something wrong? open an issue or pull request on our <a href="https://github.com/jtof-dev/meleemajors.gg" data-umami-event="github-link-clicked">github repo</a></p>
+            <p>this <a href="https://github.com/jtof-dev/meleemajors.gg" target="_blank" data-umami-event="second-github-link-clicked">website</a> is
+            open-source, and is licensed under <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" data-umami-event="license-link-clicked">agpl-3</a></p>
+            <p>powered by <a href="https://pages.github.com" target="_blank" data-umami-event="github-pages-clicked">github
+            pages</a> | made with love by <a href="https://github.com/jtof-dev" target="_blank" data-umami-event="jtof-github-clicked">jtof</a> and <a href="https://github.com/nathanbabcock" target="_blank" data-umami-event="excalo-github-clicked">excalo</a></p>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
I've been wanting to try [Umami](https://umami.is), it's a minimalist alternative to tools like Google Analytics for tracking pageviews that is easy to set up and has a nice design.

This PR adds the tracking script to `<head>`, plus [extra events](https://umami.is/docs/track-events) on all the buttons/links so we can tell what parts of the site are most valuable to people and used the most.

Here's what the dashboard looks like: https://cloud.umami.is/share/JKVhPxydVVtaKZN9/meleemajors.gg. It's actually a public URL that anyone could check out. We could make it private instead, or keep it public for transparency.