### PR TITLE
add Tango: A Doubles Major

### DIFF
--- a/ssg/src/tournaments.json
+++ b/ssg/src/tournaments.json
@@ -24,6 +24,12 @@
     "stream-url": ""
   },
   {
+    "start.gg-melee-singles-url": "https://www.start.gg/tournament/tango-a-doubles-major/event/melee-doubles",
+    "top8-start-time": "",
+    "schedule-url": "",
+    "stream-url": "https://www.twitch.tv/Mang0"
+  },
+  {
     "start.gg-melee-singles-url": "https://www.start.gg/tournament/genesis-x2/event/melee-singles",
     "top8-start-time": "",
     "schedule-url": "",


### PR DESCRIPTION
Chronologically slotted in between Platfight and GX2.

**start.gg-melee-singles-url** field links to the doubles event, as this is a doubles-focused event.
There is a singles bracket, but it is the side event.