### PR TITLE
feat: add deterministic calendar uids

### DIFF
--- a/ssg/Cargo.toml
+++ b/ssg/Cargo.toml
@@ -23,4 +23,5 @@ serde_json = { version = "1.0.117", features = ["preserve_order"] }
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-macros = "2.3.0"
 urlencoding = "2.1.3"
+uuid = { version = "1.0", features = ["v5"] }
 webbrowser = "1.0"

--- a/ssg/src/main.rs
+++ b/ssg/src/main.rs
@@ -498,12 +498,17 @@ fn generate_calendar(tournament_data: Value, calendar_ics: &mut Calendar) -> Cal
                 ))
                 .class(Class::Public)
                 .location(tournament_data["full-address"].as_str().unwrap())
-                .uid(&format!(
-                    "{}@meleemajors.gg",
-                    tournament_data["start.gg-tournament-name"]
-                        .as_str()
-                        .unwrap()
-                ))
+                .uid(&uuid::Uuid::new_v5(
+                    &uuid::Uuid::NAMESPACE_DNS,
+                    format!(
+                        "{}@meleemajors.gg",
+                        tournament_data["start.gg-tournament-name"]
+                            .as_str()
+                            .unwrap()
+                    )
+                    .as_bytes(),
+                )
+                .to_string())
                 .done(),
         )
         .done();

--- a/ssg/src/main.rs
+++ b/ssg/src/main.rs
@@ -498,6 +498,12 @@ fn generate_calendar(tournament_data: Value, calendar_ics: &mut Calendar) -> Cal
                 ))
                 .class(Class::Public)
                 .location(tournament_data["full-address"].as_str().unwrap())
+                .uid(&format!(
+                    "{}@meleemajors.gg",
+                    tournament_data["start.gg-tournament-name"]
+                        .as_str()
+                        .unwrap()
+                ))
                 .done(),
         )
         .done();


### PR DESCRIPTION
### Problem

Currently the generate_calendar function in `main.rs` calls `Event::new()` which generates a brand-new random UUID and current-timestamp DTSTAMP for every event, every run (via the icalendar crate).

This means:
     - Calendar subscribers (Google/Apple Calendar) see all events deleted and recreated every time it changes.
     - Git history is bloated with additional ICS churn


### Solution

The fix: Make UIDs deterministic in `main.rs:generate_calendar`

This change generates a UUID using each event's stable tournament slug (e.g., battleOfBc87@meleemajors.gg but it could be set to just the name too) as a seed for determinism. This ensure that the same tournament gives the same UID every run.

Calendar clients see updates to existing events, not delete+recreate. `DTSTAMP` will still change (auto-set by the crate) but that's harmless and just signals "this .ics was generated at this time."