### PR TITLE
restructure logging

### DIFF
--- a/ssg/src/mailing_list.rs
+++ b/ssg/src/mailing_list.rs
@@ -11,6 +11,11 @@ use reqwest::{
 };
 use serde_json::{json, to_string_pretty, Value};
 
+pub enum ScheduleBroadcastOutcome {
+    Created,
+    Skipped(&'static str),
+}
+
 /// Holds all the state and methods needed to interact with a third-party email
 /// provider API for scheduling tournament reminder emails.
 pub struct MailingListService {
@@ -45,7 +50,10 @@ impl MailingListService {
     }
 
     /// Schedule a reminder email for 5 days before the tournament starts
-    pub async fn schedule_reminder_broadcast(&self, tournament_data: &Value) -> Result<()> {
+    pub async fn schedule_reminder_broadcast(
+        &self,
+        tournament_data: &Value,
+    ) -> Result<ScheduleBroadcastOutcome> {
         // Determine send time (5 days before tournament start)
         let unix_start_time = tournament_data["start-unix-timestamp"]
             .as_i64()
@@ -72,17 +80,20 @@ impl MailingListService {
 
         self.create_broadcast(&send_time, &subject, &content)
             .await?;
-        log_success("email", "reminder broadcast created");
-        Ok(())
+        Ok(ScheduleBroadcastOutcome::Created)
     }
 
     /// Schedule a reminder email for the start of Top 8
-    pub async fn schedule_top8_broadcast(&self, tournament_data: &Value) -> Result<()> {
+    pub async fn schedule_top8_broadcast(
+        &self,
+        tournament_data: &Value,
+    ) -> Result<ScheduleBroadcastOutcome> {
         // Parse top 8 start time
         let top8_start_time_str = tournament_data["top8-start-time"].as_str().unwrap_or("");
         if top8_start_time_str.is_empty() {
-            log_warn("email", "missing top 8 start time");
-            return Ok(());
+            return Ok(ScheduleBroadcastOutcome::Skipped(
+                "missing top 8 start time",
+            ));
         }
         let top8_datetime_format = "%Y-%m-%d %I:%M%P"; // e.g. "2024-10-06 3:00PM"
         let timezone: Tz = tournament_data["timezone"]
@@ -108,8 +119,7 @@ impl MailingListService {
 
         self.create_broadcast(&top8_start_time, &subject, &content)
             .await?;
-        log_success("email", "top 8 broadcast created");
-        Ok(())
+        Ok(ScheduleBroadcastOutcome::Created)
     }
 
     /// Delete all scheduled (unsent) broadcasts, paginating through all results.

--- a/ssg/src/main.rs
+++ b/ssg/src/main.rs
@@ -10,6 +10,7 @@ use fs_extra::{copy_items, dir};
 use gql_client::{Client, ClientConfig};
 use icalendar::{Calendar, Class, Component, Event, EventLike};
 use itertools::Itertools;
+use mailing_list::ScheduleBroadcastOutcome;
 use regex::Regex;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -112,14 +113,31 @@ async fn main() {
         _ => panic!("root must be an array"),
     }
 
+    log_heading("Preparing output");
+
     // filter out past tournaments and sort by date (soonest first)
     let now = Utc::now().timestamp();
-    all_tournament_data.retain(|t| match t["end-unix-timestamp"].as_i64() {
-        Some(end) => end > now,
-        None => true,
-    });
+    let mut upcoming_tournament_data: Vec<Value> = Vec::new();
+    for tournament_data in all_tournament_data {
+        match tournament_data["end-unix-timestamp"].as_i64() {
+            Some(end) if end <= now => {
+                let url = tournament_data["start.gg-url"]
+                    .as_str()
+                    .unwrap_or("unknown URL");
+                let ended = unix_timestamp_to_log_date(end);
+                log_warn("data", &format!("omitting {url} ended {ended}"));
+            }
+            _ => upcoming_tournament_data.push(tournament_data),
+        }
+    }
+    let mut all_tournament_data = upcoming_tournament_data;
     all_tournament_data.sort_by_key(|t| t["start-unix-timestamp"].as_i64().unwrap_or(i64::MAX));
+    log_success(
+        "data",
+        &format!("{} upcoming tournaments", all_tournament_data.len()),
+    );
 
+    log_heading("Generating site");
     for (i, tournament_data) in all_tournament_data.iter().enumerate() {
         if i == 0 {
             index_html =
@@ -132,32 +150,7 @@ async fn main() {
         ));
 
         calendar_ics = generate_calendar(tournament_data.clone(), &mut calendar_ics);
-        log_success("calendar", "generated ICS event");
-
         api_tournaments.push(tournament_data.clone());
-
-        if let Some(ref service) = mailing_list {
-            service
-                .schedule_reminder_broadcast(tournament_data)
-                .await
-                .or_else(|e| {
-                    log_error("email", "Failed to schedule reminder broadcast");
-                    log_red(&e.to_string());
-                    Err(e)
-                })
-                .ok();
-            service
-                .schedule_top8_broadcast(tournament_data)
-                .await
-                .or_else(|e| {
-                    log_error("email", "Failed to schedule top-8 broadcast");
-                    log_red(&e.to_string());
-                    Err(e)
-                })
-                .ok();
-        } else {
-            log_warn("email", "Skipping email scheduling");
-        }
 
         if bail {
             std::process::exit(0)
@@ -165,10 +158,66 @@ async fn main() {
     }
     index_html.push_str(&format!("\n{}", index_footer_html));
     make_site(&index_html);
+    log_success("html", "wrote index.html");
     make_calendar(calendar_ics);
+    log_success(
+        "calendar",
+        &format!("generated {} ICS events", api_tournaments.len()),
+    );
     make_api(&api_tournaments);
+
+    log_heading("Scheduling email");
+    if let Some(ref service) = mailing_list {
+        for tournament_data in all_tournament_data.iter() {
+            schedule_tournament_email(service, tournament_data).await;
+        }
+    } else {
+        log_warn("email", "skipping email scheduling");
+    }
+
     cleanup_images(all_images);
     open_in_browser();
+}
+
+async fn schedule_tournament_email(
+    service: &mailing_list::MailingListService,
+    tournament_data: &Value,
+) {
+    let tournament_name = tournament_data["name"]
+        .as_str()
+        .unwrap_or("unknown tournament");
+
+    match service.schedule_reminder_broadcast(tournament_data).await {
+        Ok(ScheduleBroadcastOutcome::Created) => {
+            log_success("email", &format!("reminder created for {tournament_name}"));
+        }
+        Ok(ScheduleBroadcastOutcome::Skipped(reason)) => {
+            log_warn(
+                "email",
+                &format!("reminder skipped for {tournament_name}: {reason}"),
+            );
+        }
+        Err(e) => {
+            log_error("email", &format!("reminder failed for {tournament_name}"));
+            log_red(&e.to_string());
+        }
+    }
+
+    match service.schedule_top8_broadcast(tournament_data).await {
+        Ok(ScheduleBroadcastOutcome::Created) => {
+            log_success("email", &format!("top 8 created for {tournament_name}"));
+        }
+        Ok(ScheduleBroadcastOutcome::Skipped(reason)) => {
+            log_warn(
+                "email",
+                &format!("top 8 skipped for {tournament_name}: {reason}"),
+            );
+        }
+        Err(e) => {
+            log_error("email", &format!("top 8 failed for {tournament_name}"));
+            log_red(&e.to_string());
+        }
+    }
 }
 
 async fn scrape_data(
@@ -438,6 +487,12 @@ fn unix_timestamp_to_readable_date(date: &Value, timezone: Tz) -> String {
         .with_timezone(&timezone)
         .format("%B %d")
         .to_string()
+}
+
+fn unix_timestamp_to_log_date(timestamp: i64) -> String {
+    DateTime::from_timestamp(timestamp, 0)
+        .map(|date| date.format("%B %-d").to_string())
+        .unwrap_or_else(|| format!("invalid timestamp {timestamp}"))
 }
 
 fn download_tournament_image(url: &str, name: &str, image_data: &mut HashSet<String>) {


### PR DESCRIPTION
In https://github.com/jtof-dev/meleemajors.gg/pull/39 we fetch all tournament data up front so that we can sort + filter (based on information that doesn't get obtained until after the fetching is done), and then generate site outputs in a second pass.

This restructures the logging to reflect the two-pass system and avoid all of the email events getting jumbled together under the last tournament.

After this PR output looks like this:

```txt
❯ cargo run
   Compiling ssg v0.1.0 (C:\git\meleemajors.gg\ssg)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.93s                                                    
     Running `target\debug\ssg.exe`

 Cleaning up scheduled broadcasts 
✅ [email] deleted: Tournament reminder: Tipped Off 17: Haunted
✅ [email] deleted: Tournament reminder: Riptide 2026
✅ [email] deleted: Tournament reminder: CEO 2026
✅ [email] deleted: Tournament reminder: Supernova 2026
✅ [email] deleted: Tournament reminder: Get On My Level 2026
✅ [email] deleted: Tournament reminder: Battle of BC 8
✅ [email] deleted: Tournament reminder: Smash Camp: Heartlands
✅ [email] deleted 7 scheduled broadcasts

 Smash Camp: Heartlands 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] smashCampHeartlands.webp already exists
➖ [ffmpeg] smashCampHeartlands.thumbnail.webp already exists

 Battle of BC 8 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] battleOfBc87.webp already exists
➖ [ffmpeg] battleOfBc87.thumbnail.webp already exists

 Get On My Level 2026 - Canadian Fighting Game Championships 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] getOnMyLevel2026CanadianFightingGameChampionships.webp already exists
➖ [ffmpeg] getOnMyLevel2026CanadianFightingGameChampionships.thumbnail.webp already exists

 CEO 2026 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] ceo2026.webp already exists
➖ [ffmpeg] ceo2026.thumbnail.webp already exists

 Riptide 2026 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] riptide20264.webp already exists
➖ [ffmpeg] riptide20264.thumbnail.webp already exists

 Tipped Off 17: Haunted 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] tippedOff17Haunted.webp already exists
➖ [ffmpeg] tippedOff17Haunted.thumbnail.webp already exists

 Supernova 2026 
✅ [start.gg] scraped tournaments
✅ [start.gg] scraped entrants
✅ [start.gg] scraped top 8 players
➖ [ffmpeg] supernova2026.webp already exists
➖ [ffmpeg] supernova2026.thumbnail.webp already exists

 Preparing output 
✅ [data] 7 upcoming tournaments

 Generating site 
✅ [html] wrote index.html
✅ [calendar] generated 7 ICS events
✅ [api] validated against tournaments.schema.json
✅ [api] wrote /api/v1/tournaments.json

 Scheduling email 
✅ [email] reminder created for Smash Camp: Heartlands
⚠️  [email] top 8 skipped for Smash Camp: Heartlands: missing top 8 start time
✅ [email] reminder created for Battle of BC 8
⚠️  [email] top 8 skipped for Battle of BC 8: missing top 8 start time
✅ [email] reminder created for Get On My Level 2026
⚠️  [email] top 8 skipped for Get On My Level 2026: missing top 8 start time
✅ [email] reminder created for Supernova 2026
⚠️  [email] top 8 skipped for Supernova 2026: missing top 8 start time
✅ [email] reminder created for CEO 2026
⚠️  [email] top 8 skipped for CEO 2026: missing top 8 start time
✅ [email] reminder created for Riptide 2026
⚠️  [email] top 8 skipped for Riptide 2026: missing top 8 start time
✅ [email] reminder created for Tipped Off 17: Haunted
⚠️  [email] top 8 skipped for Tipped Off 17: Haunted: missing top 8 start time

🎉 Finished 🎉

Next steps:
1. git commit & push to main to deploy site
2. Review scheduled emails: https://app.kit.com/campaigns
3. Preview in web browser

```