### PR TITLE
refactor: begin making JSON fields provider agnostic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,14 @@
 
 ```jsonc
 {
-  "start.gg-melee-singles-url": "url to melee singles",
+  "bracketUrl": "url to melee singles",
   "top8-start-time": "YYYY-MM-DD hh:mmPM", // in the tournament's timezone
   "schedule-url": "either empty quotes or url or path to image",
   "stream-url": "either empty quotes or url to stream",
 }
 ```
 
-- the `start.gg-melee-singles-url` field is for the start.gg url to melee singles (like [https://www.start.gg/tournament/tipped-off-15-connected-1/event/melee-singles](https://www.start.gg/tournament/tipped-off-15-connected-1/event/melee-singles))
+- the `bracketUrl` field is for the start.gg url to melee singles (like [https://www.start.gg/tournament/tipped-off-15-connected-1/event/melee-singles](https://www.start.gg/tournament/tipped-off-15-connected-1/event/melee-singles))
 - the schedule url can either be a link to a website, or a relative link to an image starting from `site` - for example, `assets/schedules/tipped-off-15-schedule.webp`
 - for both `schedule-url` and `stream-url`, just leave the value blank (`""`) if there is no information about either yet
 - don't forget to add commas between tournament entries, like this:

--- a/site/api/v1/tournaments.schema.json
+++ b/site/api/v1/tournaments.schema.json
@@ -28,7 +28,7 @@
       "type": "object",
       "required": [
         "name",
-        "startggTournamentName",
+        "slug",
         "startTimestamp",
         "endTimestamp",
         "dateString",
@@ -44,7 +44,8 @@
         "streamUrl",
         "scheduleUrl",
         "imageUrl",
-        "thumbnailUrl"
+        "thumbnailUrl",
+        "startggTournamentName"
       ],
       "additionalProperties": false,
       "properties": {
@@ -53,9 +54,9 @@
           "description": "Human-readable tournament name as displayed on the site (e.g. \"Riptide 2026\", \"Pat's House 5\").",
           "examples": ["SAPF 2", "Full House: Siege"]
         },
-        "startggTournamentName": {
+        "slug": {
           "type": "string",
-          "description": "Internal slug-like identifier derived from the tournament's start.gg URL. Stable across builds and safe to use as a key.",
+          "description": "Internal slug-like identifier derived from the tournament's URL. Stable across builds and safe to use as a key.",
           "examples": ["sapf2", "fullHouseSiege"]
         },
         "startTimestamp": {
@@ -149,6 +150,12 @@
           "format": "uri",
           "description": "Absolute URL to the tournament's square thumbnail/profile image (typically used as an icon), self-hosted on meleemajors.gg. null if start.gg does not expose a distinct profile image for this tournament.",
           "examples": ["https://meleemajors.gg/assets/cards/sapf2.thumbnail.webp", null]
+        },
+        "startggTournamentName": {
+          "type": "string",
+          "deprecated": true,
+          "description": "DEPRECATED: use `slug` instead. Retained for backwards compatibility and emits the same value. Internal slug-like identifier derived from the tournament's start.gg URL.",
+          "examples": ["sapf2", "fullHouseSiege"]
         }
       }
     }

--- a/site/api/v1/tournaments.schema.json
+++ b/site/api/v1/tournaments.schema.json
@@ -39,13 +39,15 @@
         "cityAndState",
         "fullAddress",
         "mapsLink",
-        "startggUrl",
-        "startggDetailsUrl",
+        "bracketUrl",
+        "tournamentUrl",
         "streamUrl",
         "scheduleUrl",
         "imageUrl",
         "thumbnailUrl",
-        "startggTournamentName"
+        "startggTournamentName",
+        "startggUrl",
+        "startggDetailsUrl"
       ],
       "additionalProperties": false,
       "properties": {
@@ -117,15 +119,15 @@
           "description": "Google Maps search URL for the venue address. Derived from fullAddress.",
           "examples": ["https://www.google.com/maps/search/?api=1&query=..."]
         },
-        "startggUrl": {
+        "bracketUrl": {
           "type": "string",
           "format": "uri",
           "description": "Canonical start.gg URL for the main Melee singles event page."
         },
-        "startggDetailsUrl": {
+        "tournamentUrl": {
           "type": ["string", "null"],
           "format": "uri",
-          "description": "start.gg URL for the tournament's overview /details page, which lists all events and general info. Prefer this over startggUrl for general-purpose linking. null if the details URL cannot be derived from startggUrl.",
+          "description": "start.gg URL for the tournament's overview /details page, which lists all events and general info. Prefer this over bracketUrl for general-purpose linking. null if the details URL cannot be derived from bracketUrl.",
           "examples": ["https://www.start.gg/tournament/sapf-2/details", null]
         },
         "streamUrl": {
@@ -156,6 +158,19 @@
           "deprecated": true,
           "description": "DEPRECATED: use `slug` instead. Retained for backwards compatibility and emits the same value. Internal slug-like identifier derived from the tournament's start.gg URL.",
           "examples": ["sapf2", "fullHouseSiege"]
+        },
+        "startggUrl": {
+          "type": "string",
+          "format": "uri",
+          "deprecated": true,
+          "description": "DEPRECATED: use `bracketUrl` instead. Retained for backwards compatibility and emits the same value. Canonical start.gg URL for the main Melee singles event page."
+        },
+        "startggDetailsUrl": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "deprecated": true,
+          "description": "DEPRECATED: use `tournamentUrl` instead. Retained for backwards compatibility and emits the same value. start.gg URL for the tournament's overview /details page. null if the details URL cannot be derived from bracketUrl.",
+          "examples": ["https://www.start.gg/tournament/sapf-2/details", null]
         }
       }
     }

--- a/ssg/src/main.rs
+++ b/ssg/src/main.rs
@@ -244,7 +244,7 @@ async fn scrape_data(
     featured_players_json: &Value,
     all_images: &mut HashSet<String>,
 ) -> Result<Value, String> {
-    let melee_singles_url = tournament["start.gg-melee-singles-url"].as_str().unwrap();
+    let melee_singles_url = tournament["bracketUrl"].as_str().unwrap();
     let event_slug = Regex::new(r"^(https?://)?(www\.)?start\.gg/")
         .unwrap()
         .replace(melee_singles_url, "");

--- a/ssg/src/main.rs
+++ b/ssg/src/main.rs
@@ -729,7 +729,7 @@ fn tournament_to_api(t: &Value) -> Value {
 
     json!({
         "name": t["name"],
-        "startggTournamentName": t["start.gg-tournament-name"],
+        "slug": t["start.gg-tournament-name"],
         "startTimestamp": start_timestamp,
         "endTimestamp": end_timestamp,
         "dateString": t["date"],
@@ -746,6 +746,8 @@ fn tournament_to_api(t: &Value) -> Value {
         "scheduleUrl": non_empty("schedule-url"),
         "imageUrl": image_url,
         "thumbnailUrl": thumbnail_url,
+        // Deprecated: superseded by `slug`. Kept for backwards compatibility.
+        "startggTournamentName": t["start.gg-tournament-name"],
     })
 }
 

--- a/ssg/src/main.rs
+++ b/ssg/src/main.rs
@@ -740,14 +740,18 @@ fn tournament_to_api(t: &Value) -> Value {
         "cityAndState": t["city-and-state"],
         "fullAddress": t["full-address"],
         "mapsLink": t["maps-link"],
-        "startggUrl": t["start.gg-url"],
-        "startggDetailsUrl": startgg_details_url,
+        "bracketUrl": t["start.gg-url"],
+        "tournamentUrl": startgg_details_url.clone(),
         "streamUrl": non_empty("stream-url"),
         "scheduleUrl": non_empty("schedule-url"),
         "imageUrl": image_url,
         "thumbnailUrl": thumbnail_url,
         // Deprecated: superseded by `slug`. Kept for backwards compatibility.
         "startggTournamentName": t["start.gg-tournament-name"],
+        // Deprecated: superseded by `bracketUrl`. Kept for backwards compatibility.
+        "startggUrl": t["start.gg-url"],
+        // Deprecated: superseded by `tournamentUrl`. Kept for backwards compatibility.
+        "startggDetailsUrl": startgg_details_url,
     })
 }
 

--- a/ssg/src/sampleTournaments.jsonc
+++ b/ssg/src/sampleTournaments.jsonc
@@ -2,10 +2,10 @@
   {
     // The only required field. Everything else is an optional override of
     // values otherwise pulled from the start.gg API.
-    "start.gg-melee-singles-url": "url to melee singles"
+    "bracketUrl": "url to melee singles"
   },
   {
-    "start.gg-melee-singles-url": "url to melee singles",
+    "bracketUrl": "url to melee singles",
     "top8-start-time": "YYYY-MM-DD hh:mmPM", // in the tournament's timezone
     "schedule-url": "url or path to image",
     "stream-url": "url to stream (defaults to first stream listed on start.gg)",

--- a/ssg/src/tournaments.json
+++ b/ssg/src/tournaments.json
@@ -1,21 +1,21 @@
 [
   {
-    "start.gg-melee-singles-url": "https://www.start.gg/tournament/battle-of-bc-8-7/event/super-smash-bros-melee-singles"
+    "bracketUrl": "https://www.start.gg/tournament/battle-of-bc-8-7/event/super-smash-bros-melee-singles"
   },
   {
-    "start.gg-melee-singles-url": "https://www.start.gg/tournament/get-on-my-level-2026-canadian-fighting-game-championships/event/super-smash-bros-melee-singles",
+    "bracketUrl": "https://www.start.gg/tournament/get-on-my-level-2026-canadian-fighting-game-championships/event/super-smash-bros-melee-singles",
     "name": "Get On My Level 2026"
   },
   {
-    "start.gg-melee-singles-url": "https://www.start.gg/tournament/ceo-2026/event/super-smash-bros-melee"
+    "bracketUrl": "https://www.start.gg/tournament/ceo-2026/event/super-smash-bros-melee"
   },
   {
-    "start.gg-melee-singles-url": "https://www.start.gg/tournament/riptide-2026-4/event/melee-singles"
+    "bracketUrl": "https://www.start.gg/tournament/riptide-2026-4/event/melee-singles"
   },
   {
-    "start.gg-melee-singles-url": "https://www.start.gg/tournament/tipped-off-17-haunted/event/melee-singles"
+    "bracketUrl": "https://www.start.gg/tournament/tipped-off-17-haunted/event/melee-singles"
   },
   {
-    "start.gg-melee-singles-url": "https://www.start.gg/tournament/supernova-2026/event/melee-1v1-singles"
+    "bracketUrl": "https://www.start.gg/tournament/supernova-2026/event/melee-1v1-singles"
   }
 ]


### PR DESCRIPTION
Changes so far:

- rename input `tournaments.json` field `start.gg-melee-singles-url` => `bracketUrl` (internal only, no API impact)
  - adopt camelCase convention for that, although keeping other overrides as kebab-case for now
- add an API field `slug` which is identical to the old `startggTournamentName`
- deprecate the old `startggTournamentName` but keep it required

Later we will probably migrate `startggUrl` and `startggDetailsUrl` as well in the same way. I'm not 100% sure if we want raw URLs for those or a discriminated union for different sources